### PR TITLE
Missing colors

### DIFF
--- a/themes/Codesandbox-color-theme.json
+++ b/themes/Codesandbox-color-theme.json
@@ -41,7 +41,8 @@
     "menubar.selectionBackground": "#ffffff10",
     "menubar.selectionForeground": "#ffffff",
     "editorGroup.dropBackground": "#ffd3991f",
-    "editorWarning.foreground": "#FFD399"
+    "editorWarning.foreground": "#FFD399",
+    "quickInput.background": "#191d1f"
   },
   "tokenColors": [
     {

--- a/themes/Codesandbox-color-theme.json
+++ b/themes/Codesandbox-color-theme.json
@@ -42,7 +42,8 @@
     "menubar.selectionForeground": "#ffffff",
     "editorGroup.dropBackground": "#ffd3991f",
     "editorWarning.foreground": "#FFD399",
-    "quickInput.background": "#191d1f"
+    "quickInput.background": "#191d1f",
+    "editorWidget.background": "#191d1f"
   },
   "tokenColors": [
     {


### PR DESCRIPTION
Adds `quickInput.background` and `editorWidget.background` for consistency with the rest of the theme.